### PR TITLE
fix(vim): resolve <Tab> conflict between copilot and snipMate

### DIFF
--- a/.github/workflows/vim.yml
+++ b/.github/workflows/vim.yml
@@ -1,0 +1,86 @@
+name: Vim
+
+# Only run when something Vim-related changes, so unrelated PRs don't pay for
+# a full plugin install.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'rc.d/vimrc'
+      - 'rc.d/vim/**'
+      - 'setup.d/vim.sh'
+      - '.github/workflows/vim.yml'
+  pull_request:
+    paths:
+      - 'rc.d/vimrc'
+      - 'rc.d/vim/**'
+      - 'setup.d/vim.sh'
+      - '.github/workflows/vim.yml'
+
+jobs:
+  vim-setup:
+    # Verify the Vim setup: vim-plug installs every declared plugin and the
+    # vimrc sources without a <Tab> mapping conflict (E227, copilot vs snipMate).
+    # YouCompleteMe is excluded here — its huge recursive clone and native
+    # compile (handled by setup.d/vim.sh) are too heavy for CI — but every other
+    # declared plugin is installed and checked.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Vim
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y vim
+
+      - name: Link Vim config into $HOME
+        run: |
+          ln -sfn "$PWD/rc.d/vimrc" "$HOME/.vimrc"
+          ln -sfn "$PWD/rc.d/vim"  "$HOME/.vim"
+
+      - name: Install vim-plug and plugins
+        run: |
+          curl -sfLo rc.d/vim/autoload/plug.vim --create-dirs \
+            https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+          # Install every declared plugin except YouCompleteMe (see job comment).
+          # Some `do` hooks need toolchains not present here (go/yarn/npm); they
+          # may warn but don't block clones, and the assertions below check what
+          # actually matters.
+          list="$(grep -oE "Plug '[^']+'" rc.d/vimrc \
+            | sed "s/Plug '//; s/'//; s#.*/##" \
+            | grep -vx 'YouCompleteMe' | sort -u | tr '\n' ' ')"
+          echo "Installing: $list"
+          vim --not-a-term -es -c "PlugInstall --sync $list" -c 'qall!' || true
+
+      - name: Verify vimrc sources without a <Tab> conflict (E227)
+        run: |
+          set -euo pipefail
+          out="$(mktemp)"
+          # Load the real vimrc with all plugins active; E227 fires here if
+          # copilot and snipMate both try to own <Tab>.
+          vim --not-a-term -es -u "$HOME/.vimrc" \
+            -c 'redir! > '"$out" \
+            -c 'silent! echon "errmsg=[" . v:errmsg . "]"' \
+            -c 'redir END' -c 'qall!' 2>/dev/null || true
+          echo "startup $(cat "$out")"
+          if grep -q 'E227' "$out"; then
+            echo "✗ <Tab> mapping conflict (E227) at startup"
+            exit 1
+          fi
+          echo "✓ no <Tab> mapping conflict at startup"
+
+      - name: Verify all declared plugins are installed
+        run: |
+          set -euo pipefail
+          grep -oE "Plug '[^']+'" rc.d/vimrc \
+            | sed "s/Plug '//; s/'//; s#.*/##" \
+            | grep -vx 'YouCompleteMe' | sort -u > /tmp/declared.txt
+          ls "$HOME/.vim/plugged" | sort > /tmp/installed.txt
+          missing="$(comm -23 /tmp/declared.txt /tmp/installed.txt)"
+          if [ -n "$missing" ]; then
+            echo "✗ declared but not installed:"
+            echo "$missing"
+            exit 1
+          fi
+          echo "✓ all $(wc -l < /tmp/declared.txt) declared plugins installed (YouCompleteMe excluded)"

--- a/.github/workflows/vim.yml
+++ b/.github/workflows/vim.yml
@@ -51,7 +51,15 @@ jobs:
             | sed "s/Plug '//; s/'//; s#.*/##" \
             | grep -vx 'YouCompleteMe' | sort -u | tr '\n' ' ')"
           echo "Installing: $list"
-          vim --not-a-term -es -c "PlugInstall --sync $list" -c 'qall!' || true
+          # -u is required so the vimrc (which calls plug#begin) is sourced and
+          # PlugInstall is defined; otherwise the command is unknown and nothing
+          # installs.
+          vim --not-a-term -es -u "$HOME/.vimrc" -c "PlugInstall --sync $list" -c 'qall!' || true
+          # Fail loudly if nothing was actually installed (e.g. vimrc didn't load).
+          if [ ! -d "$HOME/.vim/plugged" ] || [ -z "$(ls -A "$HOME/.vim/plugged")" ]; then
+            echo "✗ no plugins were installed — vimrc/plug#begin likely did not run"
+            exit 1
+          fi
 
       - name: Verify vimrc sources without a <Tab> conflict (E227)
         run: |

--- a/rc.d/vimrc
+++ b/rc.d/vimrc
@@ -53,6 +53,13 @@ if v:version > 801 || (v:version == 801 && has( 'patch2269' ))
   Plug 'ycm-core/YouCompleteMe'
 endif
 
+" Reserve <Tab> for vim-snipmate. copilot.vim maps <Tab> in insert mode by
+" default, which collides with snipMate's `imap <unique> <Tab>` (E227). This
+" must be set before plug#end() because copilot installs its mapping while its
+" plugin is sourced there. Copilot suggestions are accepted with <C-L> instead
+" (see the Copilot section below).
+let g:copilot_no_tab_map = v:true
+
 " All of your Plugins must be added before the following line
 call plug#end()
 filetype plugin indent on    " required
@@ -232,6 +239,13 @@ endif
 " Goyo
 " =================================================
 let g:goyo_width = 120
+
+" =================================================
+" Copilot
+" =================================================
+" <Tab> is reserved for snipMate (see g:copilot_no_tab_map before plug#end()).
+" Accept Copilot suggestions with <C-L> instead.
+imap <silent><script><expr> <C-L> copilot#Accept("\<CR>")
 
 " =================================================
 " Snipmate


### PR DESCRIPTION
## Summary

`copilot.vim` maps `<Tab>` in insert mode by default, which collided with `vim-snipmate`'s `imap <unique> <Tab>` and raised **E227: Mapping already exists for <Tab>** at every Vim startup. Found while verifying the vim-plug setup.

## Fix

- Set `g:copilot_no_tab_map = v:true` **before** `plug#end()` (copilot installs its mapping while its plugin is sourced there), so `<Tab>` stays with snipMate.
- Accept Copilot suggestions with `<C-L>` instead.

## CI guard

Adds a path-filtered `Vim` workflow (`.github/workflows/vim.yml`) that runs only when Vim files change. It installs every declared plugin via vim-plug (excluding the heavy YouCompleteMe native build) and asserts the vimrc sources with **no E227**, locking in this fix against regressions.

## Verification (headless)

After the change:
- `imap <Tab>` → `<Plug>snipMateNextOrTrigger`
- `imap <C-L>` → `copilot#Accept()`
- No E227; vimrc sources cleanly.